### PR TITLE
chore: bump simple-icons to 16.8.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ catalogs:
       specifier: ^0.510.0
       version: 0.510.0
     simple-icons:
-      specifier: ^14.13.0
-      version: 14.15.0
+      specifier: ^16.8.0
+      version: 16.8.0
   react:
     '@types/react':
       specifier: ^19.0.0
@@ -107,7 +107,7 @@ importers:
         version: 2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       simple-icons:
         specifier: catalog:icons
-        version: 14.15.0
+        version: 16.8.0
     devDependencies:
       '@total-typescript/tsconfig':
         specifier: catalog:core
@@ -132,7 +132,7 @@ importers:
     dependencies:
       simple-icons:
         specifier: catalog:icons
-        version: 14.15.0
+        version: 16.8.0
     devDependencies:
       '@total-typescript/tsconfig':
         specifier: catalog:core
@@ -145,7 +145,7 @@ importers:
     dependencies:
       simple-icons:
         specifier: catalog:icons
-        version: 14.15.0
+        version: 16.8.0
     devDependencies:
       '@total-typescript/tsconfig':
         specifier: catalog:core
@@ -1882,8 +1882,8 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-icons@14.15.0:
-    resolution: {integrity: sha512-yjlJ8skP4isCd4dQTDGFbv0hQgDIr57DbWaovEeHADPAZa5DBEAs+3ZnBb76ti+yz7/OzFI3SqTP1SKku1uhCw==}
+  simple-icons@16.8.0:
+    resolution: {integrity: sha512-JOqFl9rXrUkEVwYryZVvfySG6znMg+79KpDIDtAd9mXZAPfLyhVdhhGKg7EYioYzozxXd+5KvURTMguTl0QfbA==}
     engines: {node: '>=0.12.18'}
 
   slash@3.0.0:
@@ -3623,7 +3623,7 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-icons@14.15.0: {}
+  simple-icons@16.8.0: {}
 
   slash@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,4 +26,4 @@ catalogs:
 
   icons:
     "lucide-react": ^0.510.0
-    "simple-icons": ^14.13.0
+    "simple-icons": ^16.8.0


### PR DESCRIPTION
## Summary
- Update `simple-icons` version to 16.8.0 in `pnpm-workspace.yaml` and `pnpm-lock.yaml`

## Test plan
- [x] Verify `pnpm install` resolves correctly
- [x] Confirm icons render as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency upgrade; risk is limited to potential icon name/asset changes affecting UI rendering.
> 
> **Overview**
> Bumps the `simple-icons` dependency to `16.8.0` by updating the workspace catalog entry in `pnpm-workspace.yaml` and propagating the new resolved version throughout `pnpm-lock.yaml` (including apps/packages that consume it).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2baed1879105dadc9800728d5c8fcf884f5fc33f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->